### PR TITLE
Support layout views

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ The following `compileOptions` will customize how `hapi-react-views` works.
     - `renderMethod` - the method to invoke on `React` to generate our output.
        Available options are `renderToStaticMarkup` and `renderToString`.
        Defaults to `renderToStaticMarkup`.
+    - `layoutMethod` - the method to invoke on `React` to generate output for a
+        layout template when rendering a `layout` template.
     - `removeCache` - since `node-jsx` takes a while to startup, we can remove
       templates from the cache so we don't need to restart the server to see
       changes. Defaults to `'production' !== process.env.NODE_ENV`.
@@ -108,6 +110,20 @@ server.render('template', context, renderOpts, function (err, output) {
 [Please refer to hapi's docs on
 `server.render(template, context, [options], callback)` for complete details.](http://hapijs.com/api#serverrendertemplate-context-options-callback)
 
+## Layout views
+
+When using hapi layout views defined by
+[`server.views` options](http://hapijs.com/api#serverviewsoptions)
+`layout` or `layoutPath`, the rendered component is passed to your layout
+template as `props.content`. The template can render the component using
+[dangerouslySetInnerHTML](http://facebook.github.io/react/tips/dangerously-set-inner-html.html):
+```
+<body dangerouslySetInnerHTML={{__html: this.props.content}}></body>
+```
+
+You can control the `React` render mechanism separately for layout views with
+`compileOptions.layoutMethod` to enable re-mounting the rendered component on the
+client, without unnecessarily polluting the layout HTML with `data-react-id` attributes.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -6,10 +6,10 @@ var EXT_REGEX = new RegExp('\\.jsx$');
 var DEFAULTS = {
     doctype: '<!DOCTYPE html>',
     renderMethod: 'renderToStaticMarkup',
+    layoutMethod: 'renderToStaticMarkup',
     removeCache: process.env.NODE_ENV !== 'production',
     'node-jsx': undefined
 };
-
 
 var compile = function compile(template, compileOpts) {
 
@@ -18,12 +18,20 @@ var compile = function compile(template, compileOpts) {
     require('node-jsx').install(compileOpts['node-jsx']);
 
     return function runtime(context, renderOpts) {
-
         renderOpts = Hoek.applyToDefaults(compileOpts, renderOpts);
         var output = renderOpts.doctype;
         Component = Component || require(compileOpts.filename);
         Element = Element || React.createFactory(Component);
-        output += React[renderOpts.renderMethod](Element(context));
+
+        var renderingLayout = typeof context.content === 'string' &&
+            context.content.indexOf(renderOpts.doctype) === 0;
+
+        if (renderingLayout) {
+            context.content = context.content.slice(renderOpts.doctype.length);
+            output += React[renderOpts.layoutMethod](Element(context));
+        } else {
+            output += React[renderOpts.renderMethod](Element(context));
+        }
 
         // node-jsx takes a long time to start up, so we delete
         // react modules from the cache so we don't need to restart

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-react-views",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A hapi view engine for React components.",
   "main": "index.js",
   "scripts": {

--- a/test/fixtures/component.jsx
+++ b/test/fixtures/component.jsx
@@ -1,0 +1,13 @@
+var React = require('react');
+
+
+var Component = React.createClass({
+    render: function () {
+        return (
+            <h1>{this.props.title}</h1>
+        );
+    }
+});
+
+
+module.exports = Component;

--- a/test/fixtures/layout.jsx
+++ b/test/fixtures/layout.jsx
@@ -1,0 +1,22 @@
+var React = require('react');
+
+
+var Layout = React.createClass({
+    render: function () {
+        var content = {
+            __html: this.props.content
+        };
+        return (
+            <html>
+                <head>
+                    <title>{this.props.title}</title>
+                </head>
+                <body dangerouslySetInnerHTML={content}>
+                </body>
+            </html>
+        );
+    }
+});
+
+
+module.exports = Layout;

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 var Lab = require('lab');
 var Code = require('code');
 var Hapi = require('hapi');
+var Hoek = require('hoek');
 var HapiReactViews = require('../index');
 
 
@@ -95,6 +96,109 @@ lab.experiment('Rendering', function () {
             server.render('view', context, renderOpts, function (err, output) {
 
                 Code.expect(err).to.not.exist();
+                done();
+            });
+        });
+    });
+});
+
+
+lab.experiment('Layout', function () {
+
+    var createServer = function (viewOptions) {
+        var server = new Hapi.Server(0);
+        server.views(Hoek.applyToDefaults({
+            engines: {
+                jsx: HapiReactViews
+            },
+            relativeTo: __dirname,
+            path: 'fixtures'
+        }, viewOptions));
+
+        return server;
+    };
+
+    lab.test('loads default layout.jsx when layout equals true', function (done) {
+        var server = createServer({
+            layout: true
+        });
+        var context = { title: 'Woot, it rendered.' };
+        server.render('component', context, function (err, output) {
+            console.log(err);
+            Code.expect(err).to.not.exist();
+            Code.expect(output).to.include('<html>');
+            done();
+        });
+    });
+
+    lab.test('loads named layout when layout is a file name', function (done) {
+        var server = createServer({
+            layout: 'layout'
+        });
+        var context = { title: 'Woot, it rendered.' };
+        server.render('component', context, function (err, output) {
+            Code.expect(err).to.not.exist();
+            Code.expect(output).to.include('<html>');
+            done();
+        });
+    });
+
+    lab.test('passes view context to layout template', function (done) {
+        var server = createServer({
+            layout: 'layout'
+        });
+        var context = { title: 'The title text' };
+
+        server.render('component', context, function (err, output) {
+            Code.expect(err).to.not.exist();
+            Code.expect(output).to.include('<h1>' + context.title + '</h1>');
+            done();
+        });
+    });
+
+    lab.test('renders doctype declaration only on template, not component', function (done) {
+        var doctype = '<!DOCTYPE imaginary>';
+        var server = createServer({
+            layout: 'layout',
+            compileOptions: {
+                doctype: doctype
+            }
+        });
+        var context = { title: 'The title text' };
+
+        server.render('component', context, function (err, output) {
+            Code.expect(err).to.not.exist();
+            Code.expect(output.lastIndexOf(doctype)).to.equal(0);
+            done();
+        });
+    });
+
+    lab.experiment('layoutMethod option', function (done) {
+
+        lab.test('defaults to renderToStaticMarkup', function (done) {
+            var server = createServer({
+                layout: true
+            });
+            var context = { title: 'Woot, it rendered.' };
+            server.render('component', context, function (err, output) {
+                Code.expect(output).to.include('<html>');
+                Code.expect(output).not.to.include('data-react');
+                done();
+            });
+        });
+
+        lab.test('only affects layout rendering', function (done) {
+            var server = createServer({
+                layout: true,
+                compileOptions: {
+                    renderMethod: 'renderToString',
+                    layoutMethod: 'renderToStaticMarkup'
+                }
+            });
+            var context = { title: 'Woot, it rendered.' };
+            server.render('component', context, function (err, output) {
+                Code.expect(output).to.include('<html>');
+                Code.expect(output).to.include('<h1 data-react');
                 done();
             });
         });


### PR DESCRIPTION
Currently hapi-react-views doesn't fully support using `server.views.layout` templates ([docs](http://hapijs.com/api#serverviewsoptions)). 

The problems that arise are:
* doctype declaration is rendered in the layout as well as the nested component
* it is not possible to use component's `renderToString` to achieve isomorphic rendering without also doing so for the surrounding layout component. Typically for isomorphic applications we want to render the page root component into an existing document, without having React mount the entire document on the client-side. However since we are already using JSX for templating, it can be useful to render the entire page layout using React.

This pull request contains fixes for both above issues, as well as tests and updated documentation. The tests and associated fixtures should hopefully help understand the indended use case.

@jedireza please let me know if this PR needs any improvement.
