### PR TITLE
Added ability to turn off jsx compilation if not required

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ The following `compileOptions` will customize how `hapi-react-views` works.
     - `removeCache` - since `node-jsx` takes a while to startup, we can remove
       templates from the cache so we don't need to restart the server to see
       changes. Defaults to `'production' !== process.env.NODE_ENV`.
+    - `useNodeJsx` - a boolean that controls if `node-jsx` is used. Defaults to
+      `true`. Set to `false` if you're using another transformer (ex:
+      `babel/require`) or don't need `jsx` transformations.
     - `node-jsx` - options object passed to
       [`node-jsx`](https://github.com/petehunt/node-jsx)'s `install` method.
       Defaults to `undefined`.

--- a/index.js
+++ b/index.js
@@ -7,19 +7,22 @@ var DEFAULTS = {
     doctype: '<!DOCTYPE html>',
     renderMethod: 'renderToStaticMarkup',
     removeCache: process.env.NODE_ENV !== 'production',
+    useNodeJsx: true,
     'node-jsx': undefined
 };
 
 
-var compile = function compile(template, compileOpts) {
+var compile = function compile (template, compileOpts) {
 
     compileOpts = Hoek.applyToDefaults(DEFAULTS, compileOpts);
     var Component, Element;
-    require('node-jsx').install(compileOpts['node-jsx']);
 
-    return function runtime(context, renderOpts) {
+    return function runtime (context, renderOpts) {
 
         renderOpts = Hoek.applyToDefaults(compileOpts, renderOpts);
+        if (renderOpts.useNodeJsx === true) {
+            require('node-jsx').install(compileOpts['node-jsx']);
+        }
         var output = renderOpts.doctype;
         Component = Component || require(compileOpts.filename);
         Element = Element || React.createFactory(Component);

--- a/test/fixtures/view-precompiled.jsx
+++ b/test/fixtures/view-precompiled.jsx
@@ -1,0 +1,36 @@
+'use strict';
+// precompiled with Babel (like when using the require hook for Babel)
+
+var React = require('react');
+
+var Component = React.createClass({
+    displayName: 'Component',
+
+    render: function render() {
+
+        return React.createElement(
+            'html',
+            null,
+            React.createElement(
+                'head',
+                null,
+                React.createElement(
+                    'title',
+                    null,
+                    this.props.title
+                )
+            ),
+            React.createElement(
+                'body',
+                null,
+                React.createElement(
+                    'p',
+                    null,
+                    'This is precompiled.'
+                )
+            )
+        );
+    }
+});
+
+module.exports = Component;

--- a/test/index.js
+++ b/test/index.js
@@ -37,6 +37,41 @@ lab.experiment('Rendering', function () {
     });
 
 
+    lab.test('it successfully renders with jsx compilation turned off', function (done) {
+
+        var context = { title: 'Woot, with no jsx options.' };
+        var renderOpts = {
+            runtimeOptions: {
+                useNodeJsx: false
+            }
+        };
+
+        server.render('view-precompiled', context, renderOpts, function (err, output) {
+
+            Code.expect(err).to.not.exist();
+            done();
+        });
+    });
+
+
+    lab.test('it fails if rendering jsx with jsx compilation turned off', function (done) {
+
+        var context = { title: 'Ooops, node-jsx is disabled.' };
+        var renderOpts = {
+            runtimeOptions: {
+                useNodeJsx: false
+            }
+        };
+
+        server.render('view', context, renderOpts, function (err, output) {
+
+            Code.expect(err).to.exist();
+            done();
+        });
+    });
+
+
+
     lab.test('it returns an error when the path misses', function (done) {
 
         var context = { title: 'Woops.' };
@@ -92,7 +127,7 @@ lab.experiment('Rendering', function () {
 
             Code.expect(err).to.not.exist();
 
-            server.render('view', context, renderOpts, function (err, output) {
+            server.render('view', context, renderOpts, function (err, out) {
 
                 Code.expect(err).to.not.exist();
                 done();


### PR DESCRIPTION
Adds ability to turn off jsx compilation if not required - for example if using babel's require hook or writing in ES5 style React.

This is especially useful as node-jsx is super slow and it eliminates the need for this when it's not required.