### PR TITLE
Add support for react 14

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var Hoek = require('hoek');
 var React = require('react');
+var ReactDOMServer = require('react-dom/server');
 
 
 var EXT_REGEX = new RegExp('\\.jsx$');
@@ -26,7 +27,7 @@ var compile = function compile (template, compileOpts) {
         var output = renderOpts.doctype;
         Component = Component || require(compileOpts.filename);
         Element = Element || React.createFactory(Component);
-        output += React[renderOpts.renderMethod](Element(context));
+        output += ReactDOMServer[renderOpts.renderMethod](Element(context));
 
         // node-jsx takes a long time to start up, so we delete
         // react modules from the cache so we don't need to restart

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "node-jsx": "^0.13.x"
   },
   "peerDependencies": {
-    "react": "^0.13.x"
+    "react": "^0.14.x ",
+    "react-dom": "^0.14.x "
   },
   "devDependencies": {
     "code": "^1.x.x",
@@ -38,7 +39,8 @@
     "inert": "^3.x.x",
     "jsx-loader": "^0.13.x",
     "lab": "^5.x.x",
-    "react": "^0.13.x",
+    "react": "^0.14.x ",
+    "react-dom": "^0.14.x ",
     "vision": "^3.x.x",
     "webpack": "^1.x.x"
   }


### PR DESCRIPTION
Use ReactDOMServer to render server side markup.

I'm not sure how to handle legacy support.  Any ideas?