### PR TITLE
Check for default export in es2015 files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,0 @@
-# 4 space indentation
-[*.js]
-indent_style = space
-indent_size = 4
-[*.jsx]
-indent_style = space
-indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 examples/remount/assets
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,18 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
-  - "0.11"
-  - "0.12"
+  - "4"
+  - "5"
+cache:
+  apt: true
+  directories:
+    - 'node_modules'
+addons:
+  apt:
+    sources:
+      - 'ubuntu-toolchain-r-test'
+    packages:
+      - 'gcc-4.8'
+      - 'g++-4.8'
+env:
+  - 'CXX=g++-4.8'

--- a/README.md
+++ b/README.md
@@ -40,18 +40,20 @@ available.
 Configuring the server manually:
 
 ```js
-var Hapi = require('hapi');
-var Vision = require('vision');
-var HapiReactViews = require('hapi-react-views');
+import Hapi from 'hapi';
+import Vision from 'vision';
+import HapiReactViews from 'hapi-react-views';
 
-require('babel/register')({});
+require('babel-core/register')({
+    presets: ['react', 'es2015']
+});
 
-var server = new Hapi.Server();
+const server = new Hapi.Server();
 
 server.register(Vision, function (err) {
 
     if (err) {
-        console.log("Failed to load vision.");
+        console.log('Failed to load vision.');
     }
 
     server.views({
@@ -116,8 +118,8 @@ The following `compileOptions` will customize how `hapi-react-views` works.
 You're able to override all these `compileOptions` at runtime.
 
 ```js
-var context = { name: 'Steve' };
-var renderOpts = {
+const context = { name: 'Steve' };
+const renderOpts = {
     runtimeOptions: {
         doctype: '<!DOCTYPE html>',
         renderMethod: 'renderToString'

--- a/examples/layout/server.js
+++ b/examples/layout/server.js
@@ -3,6 +3,11 @@ var Vision = require('vision');
 var HapiReactViews = require('../..');
 
 
+require('babel-core/register')({
+    presets: ['react', 'es2015']
+});
+
+
 var server = new Hapi.Server();
 server.connection();
 server.register(Vision, function (err) {

--- a/examples/remount/server.js
+++ b/examples/remount/server.js
@@ -5,7 +5,9 @@ var Vision = require('vision');
 var HapiReactViews = require('../..');
 
 
-require('babel/register')({});
+require('babel-core/register')({
+    presets: ['react', 'es2015']
+});
 
 
 var server = new Hapi.Server();

--- a/examples/remount/webpack.js
+++ b/examples/remount/webpack.js
@@ -10,8 +10,12 @@ module.exports = {
         filename: Path.join(__dirname, './assets/client.js')
     },
     module: {
-        loaders: [
-            { test: /\.jsx$/, loader: 'babel-loader' }
-        ]
+        loaders: [{
+            test: /\.jsx$/,
+            loader: 'babel-loader',
+            query: {
+                presets: ['react', 'es2015']
+            }
+        }]
     }
 };

--- a/examples/simple/server.js
+++ b/examples/simple/server.js
@@ -3,7 +3,9 @@ var Vision = require('vision');
 var HapiReactViews = require('../..');
 
 
-require('babel/register')({});
+require('babel-core/register')({
+    presets: ['react', 'es2015']
+});
 
 
 var server = new Hapi.Server();

--- a/index.js
+++ b/index.js
@@ -20,6 +20,9 @@ var compile = function compile (template, compileOpts) {
         renderOpts = Hoek.applyToDefaults(compileOpts, renderOpts);
 
         var Component = require(compileOpts.filename);
+        // support es6 default export semantics
+        Component = Component.default || Component;
+
         var Element = React.createFactory(Component);
 
         var output = renderOpts.doctype;

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "A hapi view engine for React components.",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/lab/bin/lab -c -L -I 'Reflect,core,_babelPolyfill,regeneratorRuntime,__core-js_shared__'",
-    "test-cover": "./node_modules/lab/bin/lab -c -r html -o ./test/artifacts/coverage.html && open ./test/artifacts/coverage.html",
-    "simple-example": "node ./examples/simple/server",
-    "layout-example": "node ./examples/layout/server",
-    "remount-example": "webpack --config ./examples/remount/webpack.js && node ./examples/remount/server"
+    "test": "lab -c -L -I 'Reflect,core,_babelPolyfill,regeneratorRuntime,__core-js_shared__'",
+    "test-cover": "lab -c -r html -o test/artifacts/coverage.html && open test/artifacts/coverage.html",
+    "simple-example": "node examples/simple/server",
+    "layout-example": "node examples/layout/server",
+    "remount-example": "webpack --config examples/remount/webpack.js && node examples/remount/server"
   },
   "repository": {
     "type": "git",
@@ -28,16 +28,18 @@
   },
   "homepage": "https://github.com/jedireza/hapi-react-views",
   "dependencies": {
-    "hoek": "^2.x.x"
+    "hoek": "^3.x.x"
   },
   "peerDependencies": {
     "react": "^0.14.x ",
     "react-dom": "^0.14.x "
   },
   "devDependencies": {
-    "babel": "^5.x.x",
-    "babel-core": "^5.x.x",
-    "babel-loader": "^5.x.x",
+    "babel": "~6.0.15",
+    "babel-core": "~6.0.15",
+    "babel-loader": "~6.0.1",
+    "babel-preset-es2015": "~6.0.15",
+    "babel-preset-react": "~6.0.15",
     "code": "^1.x.x",
     "hapi": "^11.x.x",
     "inert": "^3.x.x",

--- a/test/fixtures/view-es6.jsx
+++ b/test/fixtures/view-es6.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+
+class Component extends React.Component {
+
+    render () {
+
+        return (
+            <html>
+                <head>
+                    <title>{this.props.title}</title>
+                </head>
+                <body>
+                    <p>Activate the plot device.</p>
+                </body>
+            </html>
+        );
+    }
+}
+
+
+export default Component;

--- a/test/index.js
+++ b/test/index.js
@@ -5,7 +5,9 @@ var Vision = require('vision');
 var HapiReactViews = require('../index');
 
 
-require('babel/register')({});
+require('babel-core/register')({
+    presets: ['react', 'es2015']
+});
 
 
 var lab = exports.lab = Lab.script();
@@ -66,6 +68,18 @@ lab.experiment('Rendering', function () {
         var context = { title: 'Woot, it rendered.' };
 
         server.render('view', context, function (err, output) {
+
+            Code.expect(err).to.not.exist();
+            done();
+        });
+    });
+
+
+    lab.test('it successfully renders with es6 export semantics', function (done) {
+
+        var context = { title: 'Woot, it rendered.' };
+
+        server.render('view-es6', context, function (err, output) {
 
             Code.expect(err).to.not.exist();
             done();


### PR DESCRIPTION
When using ES2015 with Babel6, it appears you need to check for the default export when the react template is transpiled.

This adds a check to see if Component.default exists, if it does then it uses this instead to pass to React.createFactory