### PR TITLE
new option to remove require cache via regexp

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# 4 space indentation
+[*.js]
+indent_style = space
+indent_size = 4
+[*.jsx]
+indent_style = space
+indent_size = 4

--- a/README.md
+++ b/README.md
@@ -117,7 +117,9 @@ The following `compileOptions` will customize how `hapi-react-views` works.
     - `removeCache` - since transpilers tend to take a while to startup, we can
       remove templates from the require cache so we don't need to restart the
       server to see changes. Defaults to `'production' !==
-      process.env.NODE_ENV`. 
+      process.env.NODE_ENV`.
+    - `removeCacheRegExp` - a `RegExp` pattern string, matching modules in
+      require cache will be removed. Defaults to `undefined`.
     - `layout` - the name of the layout file to use.
     - `layoutPath` - the directory path of where layouts are stored.
     - `layoutRenderMethod` - same as `renderMethod` but used for layouts.

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "babel-loader": "6.x.x",
     "babel-preset-es2015": "6.x.x",
     "babel-preset-react": "6.x.x",
-    "code": "3.x.x",
+    "code": "4.x.x",
     "hapi": "15.x.x",
     "inert": "4.x.x",
     "lab": "11.x.x",

--- a/test/fixtures/navbar.jsx
+++ b/test/fixtures/navbar.jsx
@@ -1,15 +1,11 @@
 const React = require('react');
-const Navbar = require('./navbar.jsx');
 
 
 const Component = React.createClass({
     render: function () {
 
         return (
-            <div>
-                <Navbar />
-                <p>Activate the plot device.</p>
-            </div>
+            <div>Navbar</div>
         );
     }
 });

--- a/test/index.js
+++ b/test/index.js
@@ -127,6 +127,28 @@ lab.experiment('Rendering', () => {
             });
         });
     });
+
+
+    lab.test('it demonstrates removing matching modules from the require cache', (done) => {
+
+        const context = { title: 'Woot, it rendered.' };
+        const renderOpts = {
+            runtimeOptions: {
+                removeCacheRegExp: 'navbar'
+            }
+        };
+
+        server.render('view', context, renderOpts, (err, output) => {
+
+            Code.expect(err).to.not.exist();
+
+            server.render('view', context, renderOpts, (err, out) => {
+
+                Code.expect(err).to.not.exist();
+                done();
+            });
+        });
+    });
 });
 
 


### PR DESCRIPTION
When requiring shared components between views/layouts, updates to those shared components are still cached. In my case I know all `.jsx` files should be removed from cache.

I've added a new option `removeCacheRegExp`. A `RegExp` pattern string that matches modules in the require cache and removes them.

So in my case I'd use a pattern like: `\\.jsx$`. Since not everyone uses `.jsx` extensions, this allows you to match a pattern that exists in your app.