### PR TITLE
fix: allow peer dep of react 15 or 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "hoek": "5.x.x"
   },
   "peerDependencies": {
-    "react": ">=15",
-    "react-dom": ">=15"
+    "react": "15.x.x || 16.x.x",
+    "react-dom": "15.x.x || 16.x.x"
   },
   "devDependencies": {
     "babel-cli": "6.x.x",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "hoek": "5.x.x"
   },
   "peerDependencies": {
-    "react": "16.x.x",
-    "react-dom": "16.x.x "
+    "react": ">=15",
+    "react-dom": ">=15"
   },
   "devDependencies": {
     "babel-cli": "6.x.x",


### PR DESCRIPTION
#### Description

When `hapi-react-views` updated to react 16, there was nothing that broke support of `react@15`. This change allows the consumer to use `react@15` or greater.