### PR TITLE
React 17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ sudo: false
 language: node_js
 node_js:
   - "12"
-  - "13"
   - "14"
+  - "16"

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "@hapi/hoek": "9.x.x"
   },
   "peerDependencies": {
-    "react": "16.x.x",
-    "react-dom": "16.x.x "
+    "react": "16.x.x || ^17",
+    "react-dom": "16.x.x || ^17"
   },
   "devDependencies": {
     "@babel/cli": "7.x.x",
@@ -46,8 +46,8 @@
     "@hapi/lab": "22.x.x",
     "@hapi/vision": "6.x.x",
     "babel-loader": "8.x.x",
-    "react": "16.x.x",
-    "react-dom": "16.x.x",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "webpack": "4.x.x",
     "webpack-cli": "3.x.x"
   }


### PR DESCRIPTION
add React 17 support. I kept React 16 because that still works; but upgrading the dev dep to React 17 takes away test support for React 16.

Fixes this error in `npm` v8:
```
npm ERR! Found: react@17.0.2
npm ERR! node_modules/react
npm ERR!   react@"17.0.2" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer react@"16.x.x" from hapi-react-views@10.1.3
npm ERR! node_modules/hapi-react-views
npm ERR!   hapi-react-views@"10.1.3" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```